### PR TITLE
Updated transects/cross section runners

### DIFF
--- a/runners/cs_runner/01_transects.R
+++ b/runners/cs_runner/01_transects.R
@@ -1,11 +1,11 @@
 # Generate the flowlines layer for the final cross_sections_<VPU>.gpkg for each VPU
 source("runners/cs_runner/config.R")
 
-# # # load libraries
-library(hydrofabric3D)
-# library(terrainSliceR)
-library(dplyr)
-library(sf)
+# # # # load libraries
+# library(hydrofabric3D)
+# # library(terrainSliceR)
+# library(dplyr)
+# library(sf)
 
 # transect bucket prefix
 transects_prefix <- paste0(s3_bucket, version_prefix, "/3D/transects/")

--- a/runners/cs_runner/01_transects.R
+++ b/runners/cs_runner/01_transects.R
@@ -1,23 +1,21 @@
 # Generate the flowlines layer for the final cross_sections_<VPU>.gpkg for each VPU
-# source("runners/cs_runner/config.R")
+source("runners/cs_runner/config.R")
 
-# # load libraries
+# # # load libraries
+library(hydrofabric3D)
 # library(terrainSliceR)
-# library(dplyr)
-# library(sf)
-
-# name of S3 bucket
-s3_bucket <- "s3://lynker-spatial/"
+library(dplyr)
+library(sf)
 
 # transect bucket prefix
-transects_prefix <- paste0(s3_bucket, "v20/3D/transects/")
+transects_prefix <- paste0(s3_bucket, version_prefix, "/3D/transects/")
 
 # paths to nextgen datasets and model attribute parquet files
 nextgen_files <- list.files(nextgen_dir, full.names = FALSE)
 model_attr_files <- list.files(model_attr_dir, full.names = FALSE)
 
 # string to fill in "cs_source" column in output datasets
-net_source <- "terrainSliceR"
+net_source <- "hydrofabric3D"
 
 # ensure the files are in the same order and matched up by VPU
 path_df <- align_files_by_vpu(
@@ -33,40 +31,44 @@ for(i in 1:nrow(path_df)) {
   nextgen_file <- path_df$x[i]
   nextgen_path <- paste0(nextgen_dir, nextgen_file)
   
-  # model attributes file and full path
-  model_attr_file <- path_df$y[i]
-  model_attr_path <- paste0(model_attr_dir, model_attr_file)
+  # # model attributes file and full path
+  # model_attr_file <- path_df$y[i]
+  # model_attr_path <- paste0(model_attr_dir, model_attr_file)
 
-  message("Creating VPU ", path_df$vpu[i], " transects:\n - flowpaths: '", nextgen_file, "'\n - model attributes: '", model_attr_file, "'")
+  message("Creating VPU ", path_df$vpu[i], " transects:\n - flowpaths: '", nextgen_file, "'")
+  # message("Creating VPU ", path_df$vpu[i], " transects:\n - flowpaths: '", nextgen_file, "'\n - model attributes: '", model_attr_file, "'")
   
   # read in nextgen data
   flines <- sf::read_sf(nextgen_path, layer = "flowpaths")
 
-  #  model attributes
-  model_attrs <- arrow::read_parquet(model_attr_path)
+  # #  model attributes
+  # model_attrs <- arrow::read_parquet(model_attr_path)
 
-  # join flowlines with model atttributes
-  flines <- dplyr::left_join(
-    flines,
-    dplyr::select(
-      model_attrs,
-      id, eTW
-    ),
-    by = "id"
-  )
-  
+  # # join flowlines with model atttributes
+  # flines <- dplyr::left_join(
+  #   flines,
+  #   dplyr::select(
+  #     model_attrs,
+  #     id, eTW
+  #   ),
+  #   by = "id"
+  # )
+
   # calculate bankfull width
   flines <-
     flines %>%
     dplyr::mutate(
-      bf_width = 11 * eTW
+      bf_width = exp(0.700    + 0.365* log(tot_drainage_areasqkm))
     ) %>%
-    dplyr::mutate( # if there are any NAs, use exp(0.700    + 0.365* log(tot_drainage_areasqkm)) equation to calculate bf_width
-      bf_width = dplyr::case_when(
-        is.na(bf_width) ~ exp(0.700    + 0.365* log(tot_drainage_areasqkm)),
-        TRUE            ~ bf_width
-      )
-    ) %>%
+    # dplyr::mutate(
+    #   bf_width = 11 * eTW
+    # ) %>%
+    # dplyr::mutate( # if there are any NAs, use exp(0.700    + 0.365* log(tot_drainage_areasqkm)) equation to calculate bf_width
+    #   bf_width = dplyr::case_when(
+    #     is.na(bf_width) ~ exp(0.700    + 0.365* log(tot_drainage_areasqkm)),
+    #     TRUE            ~ bf_width
+    #   )
+    # ) %>%
     dplyr::select(
       hy_id = id,
       lengthkm,
@@ -74,16 +76,17 @@ for(i in 1:nrow(path_df)) {
       bf_width,
       geometry = geom
     )
-  
+
   # flines$bf_width <- ifelse(is.na(flines$bf_width),  exp(0.700    + 0.365* log(flines$tot_drainage_areasqkm)), flines$bf_width)
 
   time1 <- Sys.time()
  # system.time({
     # create transect lines
-    transects <- terrainSliceR::cut_cross_sections(
+    transects <- hydrofabric3D::cut_cross_sections(
       net               = flines,                        # flowlines network
       id                = "hy_id",                       # Unique feature ID
-      cs_widths         = pmax(50, flines$bf_width), # cross section width of each "id" linestring ("hy_id")
+      cs_widths         = pmax(50, flines$bf_width * 11),     # cross section width of each "id" linestring ("hy_id")
+      # cs_widths         = pmax(50, flines$bf_width),     # cross section width of each "id" linestring ("hy_id")
       num               = 10,                            # number of cross sections per "id" linestring ("hy_id")
       smooth            = TRUE,                          # smooth lines
       densify           = 3,                             # densify linestring points
@@ -132,13 +135,9 @@ for(i in 1:nrow(path_df)) {
   )
   
   # command to copy transects geopackage to S3
-  if (!is.null(aws_profile)) {
-    copy_to_s3 <- paste0("aws s3 cp ", out_path, " ", transects_prefix, out_file, 
-                             ifelse(is.null(aws_profile), "", paste0(" --profile ", aws_profile)))
-  } else {
-    copy_to_s3 <- paste0("aws s3 cp ", out_path, " ", transects_prefix, out_file)
-  }
-  
+  copy_to_s3 <- paste0("aws s3 cp ", out_path, " ", transects_prefix, out_file, 
+                   ifelse(is.null(aws_profile), "", paste0(" --profile ", aws_profile))
+                   )
 
   message("Copy VPU ", path_df$vpu[i], " transects to S3:\n - S3 copy command:\n'", 
           copy_to_s3, 

--- a/runners/cs_runner/01_transects.R
+++ b/runners/cs_runner/01_transects.R
@@ -50,9 +50,7 @@ for(i in 1:nrow(path_df)) {
   #   dplyr::select(
   #     model_attrs,
   #     id, eTW
-  #   ),
-  #   by = "id"
-  # )
+  #   ), by = "id")
 
   # calculate bankfull width
   flines <-
@@ -80,7 +78,6 @@ for(i in 1:nrow(path_df)) {
   # flines$bf_width <- ifelse(is.na(flines$bf_width),  exp(0.700    + 0.365* log(flines$tot_drainage_areasqkm)), flines$bf_width)
 
   time1 <- Sys.time()
- # system.time({
     # create transect lines
     transects <- hydrofabric3D::cut_cross_sections(
       net               = flines,                        # flowlines network
@@ -100,7 +97,6 @@ for(i in 1:nrow(path_df)) {
       # precision         = 1,
       add               = TRUE                           # whether to add back the original data
     )
-  # })
     
   time2 <- Sys.time()
   time_diff <- round(as.numeric(time2 - time1 ), 2)

--- a/runners/cs_runner/02_cs_pts.R
+++ b/runners/cs_runner/02_cs_pts.R
@@ -44,8 +44,7 @@ path_df <- align_files_by_vpu(
 # then classify the points, and create a parquet file with hy_id, cs_id, pt_id, X, Y, Z data.
 # Save parquet locally and upload to specified S3 bucket
 for (i in 1:nrow(path_df)) {
-  # i = 15
-  
+
   # nextgen file and full path
   nextgen_file <- path_df$x[i]
   nextgen_path <- paste0(nextgen_dir, nextgen_file)
@@ -248,3 +247,4 @@ for (i in 1:nrow(path_df)) {
   system(copy_cs_pts_to_s3, intern = TRUE)
 
 }
+

--- a/runners/cs_runner/02_cs_pts.R
+++ b/runners/cs_runner/02_cs_pts.R
@@ -1,16 +1,18 @@
 # Generate the flowlines layer for the final cross_sections_<VPU>.gpkg for each VPU
-# source("runners/cs_runner/config.R")
+source("runners/cs_runner/config.R")
 
 # # load libraries
-# library(terrainSliceR)
+# library(hydrofabric3D)
+# # library(terrainSliceR)
 # library(dplyr)
 # library(sf)
 
-# name of S3 bucket
-s3_bucket <- "s3://lynker-spatial/"
-
 # cross section bucket prefix
-cs_pts_prefix <- paste0(s3_bucket, "v20/3D/dem-cross-sections/")
+cs_pts_prefix <- paste0(s3_bucket, version_prefix, "/3D/dem-cross-sections/")
+# cs_pts_prefix <- paste0(s3_bucket, "v20/3D/dem-cross-sections/")
+
+# transect bucket prefix
+transects_prefix <- paste0(s3_bucket, version_prefix, "/3D/transects/")
 
 # paths to nextgen datasets
 nextgen_files <- list.files(nextgen_dir, full.names = FALSE)
@@ -19,20 +21,31 @@ nextgen_files <- list.files(nextgen_dir, full.names = FALSE)
 transect_files <- list.files(transects_dir, full.names = FALSE)
 
 # string to fill in "cs_source" column in output datasets
-cs_source <- "terrainSliceR"
+cs_source <- "hydrofabric3D"
+
+# reference features dataframe
+ref_df <- data.frame(
+  vpu      = sapply(strsplit(ref_features, "_", fixed = TRUE), function(i) { i[1] }), 
+  ref_file = ref_features
+)
 
 # ensure the files are in the same order and matched up by VPU
 path_df <- align_files_by_vpu(
-                x    = nextgen_files,
-                y    = transect_files,
-                base = base_dir
-              )
+              x    = nextgen_files,
+              y    = transect_files,
+              base = base_dir
+            ) %>% 
+          dplyr::left_join(
+            ref_df,
+            by = "vpu"
+            )
 
 # loop over the nextgen and transect datasets (by VPU) and extract point elevations across points on each transect line,
 # then classify the points, and create a parquet file with hy_id, cs_id, pt_id, X, Y, Z data.
 # Save parquet locally and upload to specified S3 bucket
 for (i in 1:nrow(path_df)) {
-
+  # i = 15
+  
   # nextgen file and full path
   nextgen_file <- path_df$x[i]
   nextgen_path <- paste0(nextgen_dir, nextgen_file)
@@ -40,8 +53,17 @@ for (i in 1:nrow(path_df)) {
   # model attributes file and full path
   transect_file <- path_df$y[i]
   transect_path <- paste0(transects_dir, transect_file)
-  message("Creating VPU ", path_df$vpu[i], " cross section points:\n - flowpaths: '", nextgen_file, "'\n - transects: '", transect_file, "'")
   
+  # model attributes file and full path
+  ref_file <- path_df$ref_file[i]
+  ref_path <- paste0(ref_features_dir, "gpkg/", ref_file)
+  
+  message("Creating VPU ", path_df$vpu[i], 
+          " cross section points:\n - flowpaths: '", nextgen_file,
+          "'\n - transects: '", transect_file, "'", 
+          "\n - waterbodies: '", ref_file, "'"
+          )
+
   ################### 
   
     # read in transects data
@@ -50,21 +72,45 @@ for (i in 1:nrow(path_df)) {
     # read in nextgen data
     flines <- sf::read_sf(nextgen_path, layer = "flowpaths")
   
-    transects <-
-      transects  %>%
-      dplyr::rename(lengthm = cs_lengthm)
+    # read in waterbodies reference features layer
+    waterbodies <- sf::read_sf(ref_path, layer = "waterbodies")
+
+    ##### subset flowlines and transects to first 5 features for testing #####
+    # flines = dplyr::slice(flines, 1:5) 
+    # transects = dplyr::filter(transects, hy_id %in% unique(flines$id))
+    ##### #####
+
+    # Update flowlines and transects to remove flowlines and transects that intersect with reference_features waterbodies
+    feature_subsets <- wb_intersects(flines, transects, waterbodies)
+
+    # replace flowlines and transects objects with updated versions in "updated_features"
+    flines    <- flines[feature_subsets$valid_flowlines, ]
+    transects <- transects[feature_subsets$valid_transects, ]
 
     # get start time for log messages
     time1 <- Sys.time()
-    
+
     # get cross section point elevations
-    cs_pts <- terrainSliceR::cross_section_pts(
-              cs             = transects[lengths(sf::st_intersects(transects, flines)) == 1, ],
-              points_per_cs  = NULL,
-              min_pts_per_cs = 10,
-              dem            = DEM_URL
-              )
-    
+    cs_pts <- hydrofabric3D::cross_section_pts(
+      cs             = transects,
+      points_per_cs  = NULL,
+      min_pts_per_cs = 10,
+      dem            = DEM_URL
+      )
+
+    # try to extend any cross sections that returned cross section points with 
+    # identical Z values within a certain threshold ("flat" cross sections)
+    cs_pts <- hydrofabric3D::rectify_flat_cs(
+      net            = flines,
+      cs             = transects,
+      cs_pts         = cs_pts, 
+      points_per_cs  = NULL,
+      min_pts_per_cs = 10,
+      dem            = DEM_URL,
+      scale          = EXTENSION_PCT,
+      threshold      = 0
+    )
+
     # get end time for log messages
     time2 <- Sys.time()
     time_diff <- round(as.numeric(time2 - time1 ), 2)
@@ -78,12 +124,83 @@ for (i in 1:nrow(path_df)) {
       dplyr::group_by(hy_id, cs_id) %>% 
       dplyr::filter(!any(is.na(Z))) %>% 
       dplyr::ungroup()
+
+    # # check the number of cross sections that were extended
+    # cs_pts$is_extended %>% table()
+
+    # extract cross section points that have an "is_extended" value of TRUE
+    extended_pts = 
+      cs_pts %>% 
+      dplyr::filter(is_extended) %>% 
+      dplyr::mutate(tmp_id = paste0(hy_id, "_", cs_id)) 
+
+    # extract transects that have a "hy_id" in the "extended_pts" dataset
+    update_transects = 
+      transects %>% 
+      dplyr::mutate(tmp_id = paste0(hy_id, "_", cs_id)) %>%
+      dplyr::filter(tmp_id %in% unique(extended_pts$tmp_id))
+      
+    # if any transects were extended, update the transects dataset, and overwrite local and S3 transects geopackages
+    if (nrow(update_transects) > 0) {
+      message("Updating ", nrow(update_transects), " transects")
+
+      update_transects =
+        update_transects %>%
+        # dplyr::filter(hy_id %in% unique(extended_pts$hy_id)) %>% 
+        # apply extend_by_percent function to each transect line: 
+        hydrofabric3D:::extend_by_percent(
+          pct        = EXTENSION_PCT,
+          length_col = "cs_lengthm"
+        )
+
+    # remove old transects that have "tmp_id" in "extended_pts", and replace with "update_transects"
+    out_transects = 
+      transects %>% 
+      dplyr::mutate(tmp_id = paste0(hy_id, "_", cs_id)) %>%
+      dplyr::filter(!tmp_id %in% unique(extended_pts$tmp_id)) %>%
+      dplyr::bind_rows(
+        update_transects
+        )  %>% 
+      # dplyr::mutate(is_extended = FALSE) %>%
+      # dplyr::bind_rows(
+      #   dplyr::mutate(update_transects, is_extended = TRUE)
+      #   )  %>% 
+      dplyr::select(-tmp_id) 
+
+    # mapview::mapview(transects, color = "red") +
+    #  mapview::mapview(dplyr::filter(out_transects, is_extended), color = "green") +
+    #  mapview::mapview(flines, color = "dodgerblue") 
+
+    ###################################### 
     
+    ## Save local and REUPLOAD TRANSECTS to S3 to update for any extended cross sections
+    message("Saving updated transects to:\n - filepath: '", transect_path, "'")
+  
+    # save flowlines to out_path (lynker-spatial/01_transects/transects_<VPU num>.gpkg)
+    sf::write_sf(
+      out_transects,
+      transect_path
+    )
+
+    # command to copy transects geopackage to S3
+    trans_to_s3 <- paste0("aws s3 cp ", transect_path, " ", transects_prefix, transect_file, 
+                            ifelse(is.null(aws_profile), "", paste0(" --profile ", aws_profile)))
+
+    message("Copy VPU ", path_df$vpu[i], " transects to S3:\n - S3 copy command:\n'", 
+            trans_to_s3, 
+            "'\n==========================")
+    
+    system(trans_to_s3, intern = TRUE)
+
+    ###################################### 
+
+    }
+
     # classify the cross section points
     cs_pts <-
       cs_pts %>%
-      dplyr::rename(cs_widths = lengthm) %>%
-      terrainSliceR::classify_points() %>%
+      dplyr::rename(cs_widths = cs_lengthm) %>%
+      hydrofabric3D::classify_points() %>%
       dplyr::mutate(
         X = sf::st_coordinates(.)[,1],
         Y = sf::st_coordinates(.)[,2]
@@ -95,7 +212,7 @@ for (i in 1:nrow(path_df)) {
         X, Y, Z,
         class
         )
-    
+
   # Drop point geometries, leaving just X, Y, Z values
   cs_pts <- sf::st_drop_geometry(cs_pts)
 
@@ -106,9 +223,10 @@ for (i in 1:nrow(path_df)) {
       Z_source = cs_source
       ) %>%
     dplyr::relocate(hy_id, cs_id, pt_id, cs_lengthm, relative_distance, X, Y, Z, Z_source, class)
-  
-  ################### 
-  
+
+  ###################################### 
+
+  ###################################### 
   # name of file and path to save transects gpkg too
   out_file <- paste0("nextgen_", path_df$vpu[i], "_cross_sections.parquet")
   out_path <- paste0(cs_pts_dir, out_file)
@@ -119,17 +237,12 @@ for (i in 1:nrow(path_df)) {
   arrow::write_parquet(cs_pts, out_path)
   
   # command to copy cross section points parquet to S3
-  if (!is.null(aws_profile)) {
-    copy_cs_pts_to_s3 <- paste0("aws s3 cp ", out_path, " ", cs_pts_prefix, out_file,
-                                    ifelse(is.null(aws_profile), "", paste0(" --profile ", aws_profile)))
-  } else {
-    copy_cs_pts_to_s3 <- paste0("aws s3 cp ", out_path, " ", cs_pts_prefix, out_file)
-    
-  }
+  copy_cs_pts_to_s3 <- paste0("aws s3 cp ", out_path, " ", cs_pts_prefix, out_file,
+                          ifelse(is.null(aws_profile), "", paste0(" --profile ", aws_profile)))
 
   message("Copy VPU ", path_df$vpu[i], " cross sections to S3:\n - S3 copy command:\n'", 
           paste0("aws s3 cp ", out_path, " ", cs_pts_prefix, out_file,
-                 ifelse(is.null(aws_profile), "", paste0(" --profile ", aws_profile))), 
+                ifelse(is.null(aws_profile), "", paste0(" --profile ", aws_profile))), 
           "'\n==========================")
   
   system(copy_cs_pts_to_s3, intern = TRUE)

--- a/runners/cs_runner/config.R
+++ b/runners/cs_runner/config.R
@@ -141,8 +141,6 @@ align_files_by_vpu <- function(
 wb_intersects <- function(flowlines, trans, waterbodies) {
 
   ########  ########  ########  ########  ########  ########
-  ########  ########  ########  ########  ########  ########
-  # if(type == 1) {
     
     flowlines_geos <- geos::as_geos_geometry(flowlines)
     wbs_geos <- geos::as_geos_geometry(waterbodies)
@@ -162,10 +160,6 @@ wb_intersects <- function(flowlines, trans, waterbodies) {
     # subset transects to the hy_ids in "to_check" set of flowlines
     trans_check <- trans[trans$hy_id %in% unique(to_check$id), ]
     # trans_check <- trans_geos[trans$hy_id %in% unique(to_check$id)]
-    
-    # trans[trans$hy_id %in% unique(to_check$id), ] %>% nrow()
-    # 
-    # trans_geos[trans$hy_id %in% unique(to_check$id)]
     
     # check where the transects linestrings intersect with the waterbodies
     trans_geos_check <- geos::as_geos_geometry(trans_check)
@@ -199,7 +193,7 @@ wb_intersects <- function(flowlines, trans, waterbodies) {
     # also the transects that do NOT intersect waterbodies but are on a flowline that DOES intersect a waterbody
     valid_flowlines <- flowlines$id %in% to_keep$id
     valid_transects <- trans$tmp_id %in% dplyr::filter(trans,
-                                                       !tmp_id %in% check_ids[!check_ids %in% keep_ids])$tmp_id
+                                                    !tmp_id %in% check_ids[!check_ids %in% keep_ids])$tmp_id
     
     # return alist of updated flowlines and transects 
     return(
@@ -208,84 +202,4 @@ wb_intersects <- function(flowlines, trans, waterbodies) {
         "valid_transects" =  valid_transects
       )
     )
-  # }
-  ########  ########  ########  ########  ########  ########
-  ########  ########  ########  ########  ########  ########
-  # if(type == 2) {
-  # 
-  #   # temporary ID for transects that is the "hy_id", underscore, "cs_id", used for subsetting in future steps
-  #   trans$tmp_id <- paste0(trans$hy_id, "_", trans$cs_id)
-  #   
-  #   # trans$order <- 1:nrow(trans)
-  #   
-  #   message("Checking flowlines against waterbodies...")
-  #   
-  #   # create an index between flowlines and waterbodies 
-  #   wb_index <- sf::st_intersects(flowlines, waterbodies)
-  #   
-  #   # remove any flowlines that cross more than 1 waterbody
-  #   to_keep <- flowlines[lengths(wb_index) == 0, ]
-  #   to_check <- flowlines[lengths(wb_index) != 0, ]
-  #   
-  #   # subset transects to the hy_ids in "to_check" set of flowlines
-  #   trans_check <- trans[trans$hy_id %in% unique(to_check$id), ]
-  #   
-  #   message("Checking transects against waterbodies...")
-  #   
-  #   # check where the transects linestrings intersect with the waterbodies
-  #   trans_wb_index <- sf::st_intersects(trans_check, 
-  #                                       waterbodies[unlist(wb_index), ]
-  #   )
-  #   # trans_wb_index <- sf::st_intersects(trans_check, wbs)
-  #   
-  #   # within the transects lines that are on a flowline that crosses a waterbody, 
-  #   # check if any of these transects line DO NOT CROSS A WATERBODY AT ALL
-  #   trans_keep <- trans_check[lengths(trans_wb_index) == 0, ]
-  #   
-  #   # preserve any flowlines that CROSS A WATERBODY BUT ALSO HAVE A TRANSECT LINE that does NOT cross any waterbodies
-  #   to_check <- to_check[to_check$id %in% unique(trans_keep$hy_id), ]
-  #   
-  #   # update flowlines to keep with flowlines that intersect a waterbody BUT STILL,
-  #   # have transects that are NOT in the waterbody
-  #   to_keep <- dplyr::bind_rows(to_keep, to_check)
-  #   
-  #   # 'tmp_ids' of transects that are being checked and also the transects within trans_check 
-  #   # that were determined to be valid (are being kept)
-  #   check_ids <- unique(trans_check$tmp_id)
-  #   keep_ids <- unique(trans_keep$tmp_id)
-  #   
-  #   # logical vectors of which flowlines/transects to keep (KEEP == TRUE)
-  #   # - Remove any transects that are on flowlines that cross a waterbody AND the transect crosses the waterbody too.
-  #   # - Keep original transects that are not on flowlines that intersect waterbodies AND 
-  #   # also the transects that do NOT intersect waterbodies but are on a flowline that DOES intersect a waterbody
-  #   valid_flowlines <- flowlines$id %in% to_keep$id
-  #   valid_transects <- trans$tmp_id %in% dplyr::filter(trans,
-  #                                                      !tmp_id %in% check_ids[!check_ids %in% keep_ids])$tmp_id
-  #   
-  #   # return alist of updated flowlines and transects 
-  #   return(
-  #     list(
-  #       "valid_flowlines" =  valid_flowlines,
-  #       "valid_transects" =  valid_transects
-  #     )
-  #   )
-  #   
-  #   # # - Remove any transects that are on flowlines that cross a waterbody AND the transect crosses the waterbody too.
-  #   # # - Keep original transects that are not on flowlines that intersect waterbodies AND 
-  #   #     # also the transects that do NOT intersect waterbodies but are on a flowline that DOES intersect a waterbody
-  #   # trans <-
-  #   #   trans %>%
-  #   #   dplyr::filter(
-  #   #     !tmp_id %in% check_ids[!check_ids %in% keep_ids]
-  #   #     ) %>%
-  #   #   dplyr::select(-tmp_id)
-  #   # 
-  #   # # return alist of updated flowlines and transects 
-  #   # return(
-  #   #   list(
-  #   #     "flowlines" = to_keep,
-  #   #     "transects" = trans
-  #   #     )
-  #   # )
-  # }
 }

--- a/runners/cs_runner/config.R
+++ b/runners/cs_runner/config.R
@@ -21,6 +21,12 @@ s3_bucket <- "s3://lynker-spatial/"
 # name of bucket with nextgen data
 nextgen_bucket <- "lynker-spatial"
 
+# nextgen bucket folder name
+nextgen_bucket_folder <- "v20.1/gpkg/"
+
+# nextgen bucket name
+nextgen_prefix  <- paste0(s3_bucket, nextgen_bucket_folder)
+
 # reference features S3 bucket prefix
 ref_features_prefix <- "s3://lynker-spatial/00_reference_features/gpkg/"
 
@@ -29,8 +35,10 @@ version_prefix <- "v20.1"
 # version_prefix <- "v20"
 
 ### LOCAL DIRS
+
 # directory to copy nextgen bucket data too
-nextgen_dir <- paste0(base_dir, "/pre-release/")
+nextgen_dir <- paste0(base_dir, "/", nextgen_bucket_folder)
+# nextgen_dir <- paste0(base_dir, "/pre-release/")
 
 # model attributes directory
 model_attr_dir <- paste0(base_dir, "/model_attributes/")

--- a/runners/cs_runner/config.R
+++ b/runners/cs_runner/config.R
@@ -2,7 +2,8 @@
 pacman::p_load(
   archive,
   hydrofabric,
-  terrainSliceR
+  hydrofabric3D
+  # terrainSliceR
 )
 
 # load root directory 
@@ -10,9 +11,24 @@ source("runners/cs_runner/config_vars.R")
 
 sf::sf_use_s2(FALSE)
 
+### Cross section point 
+
+### S3 names
+
+# name of S3 bucket
+s3_bucket <- "s3://lynker-spatial/"
+
 # name of bucket with nextgen data
 nextgen_bucket <- "lynker-spatial"
 
+# reference features S3 bucket prefix
+ref_features_prefix <- "s3://lynker-spatial/00_reference_features/gpkg/"
+
+# S3 prefix/folder of version run
+version_prefix <- "v20.1"
+# version_prefix <- "v20"
+
+### LOCAL DIRS
 # directory to copy nextgen bucket data too
 nextgen_dir <- paste0(base_dir, "/pre-release/")
 
@@ -26,14 +42,45 @@ cs_pts_dir <- paste0(base_dir, "/02_cs_pts/")
 # final output directory with geopackages per VPU
 final_dir <- paste0(base_dir, "/cross_sections/")
 
+# directory to copy nextgen bucket data too
+ref_features_dir <- paste0(base_dir, "/00_reference_features/")
+
 # create directories 
 dir.create(transects_dir, showWarnings = FALSE)
 dir.create(cs_pts_dir,    showWarnings = FALSE)
+dir.create(ref_features_dir,     showWarnings = FALSE)
+dir.create(paste0(ref_features_dir, "gpkg/"),     showWarnings = FALSE)
 dir.create(final_dir,     showWarnings = FALSE)
 # dir.create(model_attr_dir,  showWarnings = FALSE)
 
+## Go get a list of the reference features geopackages from S3 and create a save path using the S3 file names to save reference features to local directory
 
-##### UTILITY FUNCTION FOR MATCHING FILES BASED ON VPU STRING ######
+# list objects in S3 bucket, and regular expression match to nextgen_.gpkg pattern
+list_ref_features <- paste0('#!/bin/bash
+            # AWS S3 Bucket and Directory information
+            S3_BUCKET="', ref_features_prefix , '"
+            
+            # Regular expression pattern to match object keys
+            PATTERN="reference_features.gpkg"
+
+            S3_OBJECTS=$(aws s3 ls "$S3_BUCKET" | awk \'{print $4}\' | grep -E "$PATTERN")
+            
+            echo "$S3_OBJECTS"'
+)
+
+# ---- Get a list of reference features geopackages ----
+
+# Run the script to get a list of the nextgen geopackages that matched the regular expression above
+ref_features <- system(list_ref_features, intern = TRUE)
+
+# ref features datasets
+ref_features_keys <- paste0(ref_features_prefix, ref_features)
+ref_features_files <- paste0(ref_features_dir, "gpkg/", ref_features)
+
+###
+### UTILITY FUNCTION FOR MATCHING FILES BASED ON VPU STRING ###
+###
+
 # Given 2 character vectors of filenames both including VPU strings after a "nextgen_" string, match them together to
 # make sure they are aligned and in the same order
 # x is a character vector of file paths with a VPU ID preceeded by a "nextgen_" string 
@@ -75,4 +122,162 @@ align_files_by_vpu <- function(
   
   return(matched_paths)
   
+}
+
+# Update flowlines and transects to remove flowlines and transects that intersect with reference_features waterbodies
+# flowlines: flowlines linestring sf object
+# trans: transects linestring sf object
+# waterbodies: waterbodies polygon sf object
+# Returns a list of length 2 with logical vectors that subsets the "flowlines" and "transects" sf objects to remove flowlines and transects that intersect waterbodies
+### Returns a list of length 2 with updated "flowlines" and "transects" sf objects
+wb_intersects <- function(flowlines, trans, waterbodies) {
+
+  ########  ########  ########  ########  ########  ########
+  ########  ########  ########  ########  ########  ########
+  # if(type == 1) {
+    
+    flowlines_geos <- geos::as_geos_geometry(flowlines)
+    wbs_geos <- geos::as_geos_geometry(waterbodies)
+    
+    # temporary ID for transects that is the "hy_id", underscore, "cs_id", used for subsetting in future steps
+    trans$tmp_id <- paste0(trans$hy_id, "_", trans$cs_id)
+    
+    message("Checking flowlines against waterbodies...")
+    
+    # create an index between flowlines and waterbodies 
+    wb_index <- geos::geos_intersects_matrix(flowlines_geos, wbs_geos)
+    
+    # remove any flowlines that cross more than 1 waterbody
+    to_keep  <- flowlines[lengths(wb_index) == 0, ]
+    to_check <- flowlines[lengths(wb_index) != 0, ]
+    
+    # subset transects to the hy_ids in "to_check" set of flowlines
+    trans_check <- trans[trans$hy_id %in% unique(to_check$id), ]
+    # trans_check <- trans_geos[trans$hy_id %in% unique(to_check$id)]
+    
+    # trans[trans$hy_id %in% unique(to_check$id), ] %>% nrow()
+    # 
+    # trans_geos[trans$hy_id %in% unique(to_check$id)]
+    
+    # check where the transects linestrings intersect with the waterbodies
+    trans_geos_check <- geos::as_geos_geometry(trans_check)
+    
+    message("Checking transects against waterbodies...")
+    trans_wb_index <- geos::geos_intersects_any(
+      trans_geos_check,  
+      wbs_geos[unlist(wb_index)]
+    )
+  
+    # within the transects lines that are on a flowline that crosses a waterbody, 
+    # check if any of these transects line DO NOT CROSS A WATERBODY AT ALL
+    trans_keep <- trans_check[!trans_wb_index, ]
+    # trans_keep <- trans_check[lengths(trans_wb_index2) == 0, ]
+  
+    # preserve any flowlines that CROSS A WATERBODY BUT ALSO HAVE A TRANSECT LINE that does NOT cross any waterbodies
+    to_check <- to_check[to_check$id %in% unique(trans_keep$hy_id), ]
+    
+    # update flowlines to keep with flowlines that intersect a waterbody BUT STILL,
+    # have transects that are NOT in the waterbody
+    to_keep <- dplyr::bind_rows(to_keep, to_check)
+    
+    # 'tmp_ids' of transects that are being checked and also the transects within trans_check 
+    # that were determined to be valid (are being kept)
+    check_ids <- unique(trans_check$tmp_id)
+    keep_ids <- unique(trans_keep$tmp_id)
+    
+    # logical vectors of which flowlines/transects to keep (KEEP == TRUE)
+    # - Remove any transects that are on flowlines that cross a waterbody AND the transect crosses the waterbody too.
+    # - Keep original transects that are not on flowlines that intersect waterbodies AND 
+    # also the transects that do NOT intersect waterbodies but are on a flowline that DOES intersect a waterbody
+    valid_flowlines <- flowlines$id %in% to_keep$id
+    valid_transects <- trans$tmp_id %in% dplyr::filter(trans,
+                                                       !tmp_id %in% check_ids[!check_ids %in% keep_ids])$tmp_id
+    
+    # return alist of updated flowlines and transects 
+    return(
+      list(
+        "valid_flowlines" =  valid_flowlines,
+        "valid_transects" =  valid_transects
+      )
+    )
+  # }
+  ########  ########  ########  ########  ########  ########
+  ########  ########  ########  ########  ########  ########
+  # if(type == 2) {
+  # 
+  #   # temporary ID for transects that is the "hy_id", underscore, "cs_id", used for subsetting in future steps
+  #   trans$tmp_id <- paste0(trans$hy_id, "_", trans$cs_id)
+  #   
+  #   # trans$order <- 1:nrow(trans)
+  #   
+  #   message("Checking flowlines against waterbodies...")
+  #   
+  #   # create an index between flowlines and waterbodies 
+  #   wb_index <- sf::st_intersects(flowlines, waterbodies)
+  #   
+  #   # remove any flowlines that cross more than 1 waterbody
+  #   to_keep <- flowlines[lengths(wb_index) == 0, ]
+  #   to_check <- flowlines[lengths(wb_index) != 0, ]
+  #   
+  #   # subset transects to the hy_ids in "to_check" set of flowlines
+  #   trans_check <- trans[trans$hy_id %in% unique(to_check$id), ]
+  #   
+  #   message("Checking transects against waterbodies...")
+  #   
+  #   # check where the transects linestrings intersect with the waterbodies
+  #   trans_wb_index <- sf::st_intersects(trans_check, 
+  #                                       waterbodies[unlist(wb_index), ]
+  #   )
+  #   # trans_wb_index <- sf::st_intersects(trans_check, wbs)
+  #   
+  #   # within the transects lines that are on a flowline that crosses a waterbody, 
+  #   # check if any of these transects line DO NOT CROSS A WATERBODY AT ALL
+  #   trans_keep <- trans_check[lengths(trans_wb_index) == 0, ]
+  #   
+  #   # preserve any flowlines that CROSS A WATERBODY BUT ALSO HAVE A TRANSECT LINE that does NOT cross any waterbodies
+  #   to_check <- to_check[to_check$id %in% unique(trans_keep$hy_id), ]
+  #   
+  #   # update flowlines to keep with flowlines that intersect a waterbody BUT STILL,
+  #   # have transects that are NOT in the waterbody
+  #   to_keep <- dplyr::bind_rows(to_keep, to_check)
+  #   
+  #   # 'tmp_ids' of transects that are being checked and also the transects within trans_check 
+  #   # that were determined to be valid (are being kept)
+  #   check_ids <- unique(trans_check$tmp_id)
+  #   keep_ids <- unique(trans_keep$tmp_id)
+  #   
+  #   # logical vectors of which flowlines/transects to keep (KEEP == TRUE)
+  #   # - Remove any transects that are on flowlines that cross a waterbody AND the transect crosses the waterbody too.
+  #   # - Keep original transects that are not on flowlines that intersect waterbodies AND 
+  #   # also the transects that do NOT intersect waterbodies but are on a flowline that DOES intersect a waterbody
+  #   valid_flowlines <- flowlines$id %in% to_keep$id
+  #   valid_transects <- trans$tmp_id %in% dplyr::filter(trans,
+  #                                                      !tmp_id %in% check_ids[!check_ids %in% keep_ids])$tmp_id
+  #   
+  #   # return alist of updated flowlines and transects 
+  #   return(
+  #     list(
+  #       "valid_flowlines" =  valid_flowlines,
+  #       "valid_transects" =  valid_transects
+  #     )
+  #   )
+  #   
+  #   # # - Remove any transects that are on flowlines that cross a waterbody AND the transect crosses the waterbody too.
+  #   # # - Keep original transects that are not on flowlines that intersect waterbodies AND 
+  #   #     # also the transects that do NOT intersect waterbodies but are on a flowline that DOES intersect a waterbody
+  #   # trans <-
+  #   #   trans %>%
+  #   #   dplyr::filter(
+  #   #     !tmp_id %in% check_ids[!check_ids %in% keep_ids]
+  #   #     ) %>%
+  #   #   dplyr::select(-tmp_id)
+  #   # 
+  #   # # return alist of updated flowlines and transects 
+  #   # return(
+  #   #   list(
+  #   #     "flowlines" = to_keep,
+  #   #     "transects" = trans
+  #   #     )
+  #   # )
+  # }
 }

--- a/runners/cs_runner/config_vars.R
+++ b/runners/cs_runner/config_vars.R
@@ -1,11 +1,19 @@
 ### EDIT base_dir, aws_profile, and DEM_URL ###
-base_dir    <- '/Users/anguswatters/Desktop/lynker-spatial'
+base_dir     <- '/Users/anguswatters/Desktop/lynker-spatial'
 
 # AWS profile to run CLI commands 
-aws_profile <- "angus-lynker"
+aws_profile  <- "angus-lynker"
+
+# name of S3 bucket
+s3_bucket    <- "s3://lynker-spatial/"
 
 # DEM URL
-DEM_URL     <- "/vsicurl/https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/1/TIFF/USGS_Seamless_DEM_1.vrt"
+DEM_URL      <- "/vsicurl/https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/1/TIFF/USGS_Seamless_DEM_1.vrt"
+
+# scale argument for cross_section_pts() function. 
+# The percentage of the length of the transect line to try and extend a transect to see if viable Z values can be found by extending transect line
+# Default setting is 50% of the original transect lines length (0.5)
+EXTENSION_PCT <- 0.5
 
 # # create the directory if it does NOT exist
 # if(!dir.exists(base_dir)) {

--- a/runners/cs_runner/download_nextgen.R
+++ b/runners/cs_runner/download_nextgen.R
@@ -7,8 +7,13 @@ source("runners/cs_runner/config_vars.R")
 # name of S3 bucket
 s3_bucket <- "s3://lynker-spatial/"
 
+# nextgen bucket folder name
+nextgen_bucket_folder <- "v20.1/gpkg/"
+
 # nextgen bucket name
-prerelease_prefix     <- "s3://lynker-spatial/pre-release/"
+nextgen_prefix  <- paste0(s3_bucket, nextgen_bucket_folder)
+
+# prerelease_prefix     <- "s3://lynker-spatial/pre-release/"
 
 # # reference features S3 bucket prefix
 # ref_features_prefix <- "s3://lynker-spatial/00_reference_features/gpkg/"
@@ -17,7 +22,7 @@ prerelease_prefix     <- "s3://lynker-spatial/pre-release/"
 model_attr_prefix <- paste0(s3_bucket, "v20/3D/model_attributes/")
 
 # directory to copy nextgen bucket data too
-nextgen_dir <- paste0(base_dir, "/pre-release/")
+nextgen_dir <- paste0(base_dir, "/", nextgen_bucket_folder)
 
 # create the directory if it does NOT exist
 if(!dir.exists(nextgen_dir)) {
@@ -38,7 +43,7 @@ if(!dir.exists(model_attr_dir)) {
 # list objects in S3 bucket, and regular expression match to nextgen_.gpkg pattern
 command <- paste0('#!/bin/bash
             # AWS S3 Bucket and Directory information
-            S3_BUCKET="', prerelease_prefix, '"
+            S3_BUCKET="', nextgen_prefix, '"
             DESTINATION_DIR=', nextgen_dir, '
             
             # Regular expression pattern to match object keys
@@ -57,8 +62,8 @@ bucket_keys <- system(command, intern = TRUE)
 # Parse the selected S3 objects keys and copy them to the destination directory
 for (key in bucket_keys) {
   
-  copy_cmd <- paste0('aws s3 cp ', prerelease_prefix, key, " ", nextgen_dir, key)
-  message("Copying S3 object:\n", paste0(prerelease_prefix, key))
+  copy_cmd <- paste0('aws s3 cp ', nextgen_prefix, key, " ", nextgen_dir, key)
+  message("Copying S3 object:\n", paste0(nextgen_prefix, key))
   
   system(copy_cmd)
   


### PR DESCRIPTION
- Updated `cs_runners/01_transects.R`, `cs_runners/02_cs_pts.R`, and `cs_runners/config.R` 
- Made changes to `cs_runners/01_transects.R` to apply power law bankful width calculation for initial cross section lengths and no longer using `model_attributes.parquet`
- Created a `wbs_intersects()` function to use in `cs_runners/02_cs_pts.R` to return a logical vector describing which transects and flowlines to intersect with a waterbody from `reference_features` dataset, these transects and flowlines are then removed
- Applied new `hydrofabric3D::rectify_flat_cs()` function to the outputs of `hydrofabric3D::cross_section_pts()` to try and extend any cross sections that have entirely identical (within a threshold) Z values and thus are "flat"
- Any cross sections that were extended as a result of `hydrofabric3D::rectify_flat_cs()`, were noted and the corresponding cross sections in `transects` were identified, updated (extended) and reuploaded to remote S3 bucket